### PR TITLE
fix(workspace): shell-quote ros2_workspace source path (injection + space-safe)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to **dsh-ros2** are documented here. Format follows
 
 ### Fixed
 
+- `ros2_workspace {action: "use", path}`：把 `source <path>` 前缀中的工作区
+  **路径做单引号 shell 转义**（`shq()`），不再把用户路径原样插进 `bash -lc`
+  字符串。既修复**注入面**（路径含 `;`/`&`/`$(...)` 等元字符可逃逸），也修复
+  **含空格路径**（如 `my workspace` 之前 source 会失败）。同步让
+  `extractSourcePath()` 能反解析单/双引号包裹的路径（de-quote），使存在性检查
+  与 `show` 展示仍对真实路径生效。新增 2 例回归测试（common +1、core +1）。
 - `ros2_install` PTY 交互测试：在无法分配 pty 的无头/容器环境（devpts 以
   `ptmxmode=000` 挂载，非 root 无法 `pty.openpty()`，报 "out of pty devices"）
   改为 **skip**（`it.skipIf` 探测，CI/有 pty 环境仍完整运行），不再让整个

--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ bundles you need (or the `dsh-ros2` aggregate for the full set):
 ```bash
 pnpm install
 pnpm run typecheck   # tsc --noEmit
-pnpm run test        # vitest (182 cases; plus 10 sidecar Python scenarios)
+pnpm run test        # vitest (184 cases; plus 10 sidecar Python scenarios)
 pnpm run build       # tsc -> lib/ + lib/types/
 ```
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -470,7 +470,7 @@ dsh-ros2/                      # pnpm monorepo（工作区根，private）
 ```bash
 pnpm install
 pnpm run typecheck   # tsc --noEmit
-pnpm run test        # vitest（182 例；另有 10 个 sidecar Python 场景）
+pnpm run test        # vitest（184 例；另有 10 个 sidecar Python 场景）
 pnpm run build       # tsc -> lib/ + lib/types/
 ```
 

--- a/dsh-ros2-maintain.md
+++ b/dsh-ros2-maintain.md
@@ -1,7 +1,8 @@
 # dsh-ros2 日常维护文档（Maintenance Log）
 
 > 仓库：`StvLi/dsh-ros2` · 本地代码：`/home/stvli/Desktop/embody_agent_ws/dsh-ros2`（git remote `git@github.com:StvLi/dsh-ros2.git`）
-> 维护日期：2026-09-03 · 维护者：DSH scheduled-run agent（StvLi 仓）
+> 维护日期：2026-09-04（最近一轮） · 维护者：DSH scheduled-run agent（StvLi 仓）
+> 维护轮次：第一轮 2026-09-03（§0–§7）；第二轮 2026-09-04（§8，本轮，无 open issue → 安全检查）。
 
 本文件记录 dsh-ros2 插件的一次完整日常维护循环：**查 issue → 评估建议 → 分支开发 → 验证 → 推送 → 交付维护文档**。每次维护在下方追加一节。
 
@@ -175,3 +176,72 @@ dsh-phoenix 已在 web profile 安装并生效：
 - 开分支 `fix/maintenance-daily` → 两枚提交（`fix(test)`、`docs`）→ push → PR #5。
 - 本地 typecheck/test/build 全绿；dsh-phoenix 接线核对（§4）。
 ```
+
+---
+
+## 8. 维护记录（2026-09-04 · 第二轮：无 open issue → 安全检查 + 验证）
+
+> 本轮结论：**无未处理 issue**（0 open issue / 0 open PR）。按流程 `1 → 有 issue→2,3,4 / 无 issue→5` ，直接转入**安全检查（step 5）**。
+> 因此本轮是**纯验证 + 安全检查**型维护：**未做任何代码改动**，故不新开分支、不提交、不触发 dsh-phoenix 优雅重启。
+
+### 8.0 仓库快照（本轮）
+
+| 项 | 值 |
+| --- | --- |
+| 当前分支 | `main`（= `origin/main` HEAD `ee3ae03`，工作树干净） |
+| 远端分支 | `origin/main`，`origin/docs/maintenance`（历史遗留，落后于 main；见 §5 建议清理） |
+| main CI 状态 | HEAD `ee3ae03`：check(22) / check(24) 均 `completed: success` |
+| 本地 Node / pnpm | Node `v24.16.0` / pnpm `11.22.0`（root `packageManager` 一致） |
+| 包数量 | 9 个（common/core/dsh-ros2/dsh-ros2-state/moveit/profile/safety/sidecar/vision） |
+
+### 8.1 Issue 检查（step 1）
+
+`GET /repos/StvLi/dsh-ros2/issues?state=open` → **0 open**；`/pulls?state=open` → **0 open**。
+历史全部 closed：issue #1（docs consolidate）、#2（pnpm11 build）、#3（docs counts）；PR #1、#5（已合并）。
+→ **不存在未处理 issue**，跳转安全检查；未做步骤 2/3/4 的“建议评估/分支开发”。
+
+### 8.2 本地验证（typecheck / test / build 全绿；step 0 健康检查）
+
+```bash
+CI=true pnpm run typecheck   # 9/10 工程 tsc --noEmit 全部 Done（exit 0）
+CI=true pnpm run test        # 182 vitest（core 93 过 + 1 skip）；sidecar python3 -m sidecar.selftest → SELFTEST PASSED (10 scenarios)；exit 0
+CI=true pnpm run build       # pnpm -r build 全部 Done（exit 0）
+```
+用例分布：common 13 + core 94 + moveit 16 + profile 11 + safety 8 + vision 30 + state 8 + dsh-ros2 2 = **182**（CI 允许 1 例 pty-skip）。
+
+### 8.3 安全扫描（step 5）
+
+**依赖审计（pnpm audit）**：默认 registry 为 `registry.npmmirror.com`，无 `/-/npm/v1/security/advisories/bulk` 端点（直接 `ERR_PNPM_AUDIT_ENDPOINT_NOT_EXISTS`）；须显式 `--registry=https://registry.npmjs.org`。
+结果：**No known vulnerabilities found**（exit 0，覆盖 `@deepseek-ai/dsh-tools`、`@deepseek-ai/schemastery` 等运行依赖）。
+
+**静态 / 历史扫描**：
+
+- 硬编码密钥（`AKIA…` / `sk-…` / `ghp_…` / `BEGIN RSA|OPENSSH|EC|DSA PRIVATE` / `AIza…` / `xox…`）：**源代码与 git 全历史均无泄漏**。`.gitignore` 正确排除 `secrets.json` / `*.secrets.json` / `.env` / `lib/` / `node_modules/`。
+- `eval` / `new Function` / `vm`：**无**。
+- 命令执行面：`spawn` / `execFile` 均使用**数组参数**（不做 shell 展开）；`runCommand`（`common/src/runner.ts`）对每个 arg 经 `shq()` 单引号转义——**参数层防注入**。`spawnJob` 同样数组参数。
+
+**发现（低–中，未在本轮改动，列为改进建议）**：
+
+1. **`ros2_workspace use <path>` 的会话级 source 前缀未做 shell 转义**（`packages/core/src/tools.ts:1429` `setSessionRosSetup(\`source ${setup} && \`)`）。
+   - `setup = path.join(p,'install','setup.bash')`，`p` 为用户参数；随后在 `runner.ts:168,172` 被拼接进 `bash -lc` 字符串。
+   - **实际可利用性低**：`access(setup)` 要求该**字面路径真实存在**才通过校验（含 `;` / 空格的文件名极为罕见）。
+   - 但属**隐式注入 / 误解析**风险：路径含空格会令 `source` 失败、含元字符可逃逸。
+   - **安全修复非一行**：需对 source 路径加 shell 引号（`shq()` 或内联转义）**并**同步改造 `extractSourcePath()`（`runner.ts:76`，当前正则 `\bsource\s+([^\s&;|]+)` 只捕获裸路径，会因引号误判为“路径不存在”而触发错误回退）——即 setter 与读取两端 + 补测试。本轮无驱动 issue，未扩大范围，作为建议保留。
+2. **`packages/vision/scripts/simplify_visual_meshes.py:22` 顶层 `import open3d`**：脚本 docstring 有 `pip install open3d` 说明，但无 `requirements.txt` / `pyproject.toml` 声明 → **未声明的可选运行依赖**（工具脚本、非常驻服务，风险低）。
+3. **默认 registry 无 audit 端点**：CI/维护中的 `pnpm audit` 会假失败，需显式指定官方 registry 或配置含 audit 能力 registry。
+
+### 8.4 dsh-phoenix 持续更新/测试链路核对（step 4 侧）
+
+- 安装：web profile `package.json` `dsh-phoenix: link:…/dsh-phoenix`（v0.2.6）；`dsh-ros2` 及各 `dsh-ros2-*` 包同样以 `link:` 装入。
+- 生效：`curl http://127.0.0.1:3080/__dsh_health` → `{"token":"…"}`（client 自动重连在跑）；`systemctl --user list-units` → `dsh-web.service … active running`。
+- 本轮**无运行时行为改动**，**有意不触发** dsh-phoenix 优雅重启（其触发条件为 dsh 编译插件 `cordis_run`，且会中断本会话）。
+
+### 8.5 结论与下一步建议
+
+- 本轮**无代码变更**：无 open issue + 本地验证全绿 + audit/静态扫描干净 + main CI 绿。
+- 下次维护可选：
+  1. 对 `ros2_workspace` source 前缀做 shell 转义（setter + `extractSourcePath` + 测试）。
+  2. 为 `simplify_visual_meshes.py` 补 `requirements.txt`/`pyproject` 声明 `open3d`。
+  3. `git push origin --delete docs/maintenance` 清理历史遗留分支。
+  4. README 补显式 pnpm 版本声明（CI 已固定 11.22.0）。
+  5. 沿用“提交前 typecheck+test+build 全绿 + 行为变更补测试 + push 后 CI 绿”验收线；`pnpm audit` 需加 `--registry=https://registry.npmjs.org`。

--- a/packages/common/src/runner.ts
+++ b/packages/common/src/runner.ts
@@ -48,8 +48,14 @@ function execFileP(bin: string, args: string[], options: ExecFileOptions): Promi
   })
 }
 
-/** POSIX single-quote escape for embedding one argument into a shell string. */
-function shq(value: string): string {
+/**
+ * POSIX single-quote escape for embedding one argument into a shell string.
+ * Wraps the value in single quotes and escapes embedded single quotes; the
+ * result is a single, safe shell word (no metacharacter can break out).
+ * Exported so callers that build a `source <path> && ` prefix from user
+ * input (e.g. the `ros2_workspace use <path>` tool) can quote the path.
+ */
+export function shq(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`
 }
 
@@ -71,10 +77,16 @@ export function getSessionRosSetup(): string | null {
   return sessionRosSetup
 }
 
-/** Extract the first `source <path>` from a shell prefix, if any. */
+/**
+ * Extract the source path from a shell prefix `source <path> && `, where
+ * <path> may be bare, single-quoted (shq), or double-quoted. Returns the
+ * unquoted path so callers can `existsSync` it. Bare paths are matched up to
+ * the first whitespace / shell control token (legacy behaviour); quoted
+ * paths are de-quoted so a path containing spaces round-trips correctly.
+ */
 function extractSourcePath(prefix: string): string | undefined {
-  const m = /\bsource\s+([^\s&;|]+)/.exec(prefix)
-  return m ? m[1] : undefined
+  const m = /\bsource\s+(?:'([^']*)'|"([^"]*)"|([^\s&;|]+))/.exec(prefix)
+  return m ? (m[1] ?? m[2] ?? m[3]) : undefined
 }
 
 /** First existing candidate for `/opt/ros/<distro>/setup.bash`. */

--- a/packages/common/tests/runner.spec.ts
+++ b/packages/common/tests/runner.spec.ts
@@ -78,4 +78,25 @@ describe('resolveSetup fallback chain + session override', () => {
       setSessionRosSetup(null)
     }
   })
+
+  it('de-quotes a shq()-quoted source path (even with spaces) back to the unquoted path', async () => {
+    // ros2_workspace `use` now stores `source '<path>' && ` via shq(); resolveSetup
+    // must return the RAW path so the existence check runs against the real file
+    // and the prefix round-trips unchanged instead of falsely auto-falling-back.
+    const { resolveSetup } = await import('../src/runner.js')
+    const dir = `/tmp/dsh runner ${process.pid}`
+    const { mkdirSync, writeFileSync, rmSync } = require('node:fs')
+    mkdirSync(`${dir}/install`, { recursive: true })
+    writeFileSync(`${dir}/install/setup.bash`, 'true\n')
+    const src = `${dir}/install/setup.bash`
+    const quoted = `source '${src}' && `
+    try {
+      const setup = resolveSetup({ rosSetup: quoted })
+      expect(setup.explicit).toBe(true)
+      expect(setup.sourcePath).toBe(src)
+      expect(setup.prefix).toBe(quoted)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
 })

--- a/packages/core/src/tools.ts
+++ b/packages/core/src/tools.ts
@@ -44,6 +44,7 @@ import {
   setSessionRosSetup,
   getSessionRosSetup,
   resolveSetup,
+  shq,
 } from 'dsh-ros2-common'
 import { spawnJob } from 'dsh-ros2-common'
 
@@ -1426,7 +1427,10 @@ function makeWorkspaceTool(deps: CoreToolDeps) {
           return toolError('ros2_workspace', 'ros2_workspace', 'SETUP_NOT_FOUND',
             `未找到 ${setup}。请确认该工作区已 colcon build；或检查路径下是否有 install/setup.bash。当前会话覆盖：${getSessionRosSetup() ?? '（无）'}。`)
         }
-        setSessionRosSetup(`source ${setup} && `)
+        // Quote the source path so a path containing spaces or shell
+        // metacharacters is one safe shell word — never raw-interpolated into
+        // `bash -lc` (injection + path-with-space correctness hardening).
+        setSessionRosSetup(`source ${shq(setup)} && `)
         return okResult('ros2_workspace', 'ros2_workspace', {
           action: 'use', path: p, setup,
           sessionRosSetup: getSessionRosSetup(),

--- a/packages/core/tests/tools.spec.ts
+++ b/packages/core/tests/tools.spec.ts
@@ -620,4 +620,21 @@ describe('ros2_workspace', () => {
       rmSync(dir, { recursive: true, force: true })
     }
   })
+  it('use stores the source path as a single-quoted shell word (injection/path-with-space hardening)', async () => {
+    const { mkdirSync, writeFileSync, rmSync } = await import('node:fs')
+    const dir = `/tmp/dsh ws tool test ${process.pid}`
+    mkdirSync(`${dir}/install`, { recursive: true })
+    writeFileSync(`${dir}/install/setup.bash`, 'true\n')
+    try {
+      const run = makeRun(() => ({ stdout: '' }))
+      const out = await call('ros2_workspace', run, { action: 'use', path: dir })
+      expect(out.ok).toBe(true)
+      // The prefix must be a quoted path (`source '<path>' && `), never a raw
+      // interpolation of the user path into a `bash -lc` string.
+      const prefix = (out.data as { sessionRosSetup: string }).sessionRosSetup
+      expect(prefix).toBe(`source '${dir}/install/setup.bash' && `)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
 })


### PR DESCRIPTION
## Summary

Daily-maintenance security hardening found during the 2026-09-05 round (deferred as "next round optional" in the 2026-09-04 log).

`ros2_workspace {action:'use', path}` built the session source prefix as `` source `${setup}` && `` with the user-controlled path **raw-interpolated**, then handed it to `bash -lc` in `runCommand`. A path containing shell metacharacters (`;`/`&`/`$(...)`) could break out of the intended `source` command; a path containing spaces simply failed to source.

## Changes

- **`dsh-ros2-common`**: export `shq()` (POSIX single-quote escape) and teach `extractSourcePath()` to de-quote single/double-quoted source paths, so the existence check and `show` still resolve the **real** (unquoted) path.
- **`dsh-ros2-core`**: quote the path in the `ros2_workspace use` stored prefix → `` source '${path}' && ``.
- **Tests**: +1 common (quoted path w/ spaces round-trips), +1 core (stored prefix is a single-quoted shell word). Workspace vitest count 182 → **184**.

## Validation

- `CI=true pnpm run typecheck` — 10/10 projects `Done`.
- `CI=true pnpm run test` — **184** vitest (1 pty-skip locally; green in CI) + 10 sidecar Python scenarios.
- `CI=true pnpm run build` — all `Done`.
- `pnpm audit --registry=https://registry.npmjs.org` — no known vulnerabilities.

## Security impact

Low–medium: the `access(setup)` guard requires the literal path to exist, so exploiting metacharacters requires a real dir named with control chars (rare). The fix removes the injection surface entirely and also fixes the common **path-with-spaces** breakage.