### PR TITLE
fix(vision): declare open3d runtime dep + document pnpm 11.x requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to **dsh-ros2** are documented here. Format follows
 
 ## [Unreleased]
 
+### Added
+
+- `packages/vision/scripts/requirements.txt`：为离屏低模脚本
+  `simplify_visual_meshes.py` 显式声明运行依赖 **`open3d`**（此前仅在脚本 docstring
+  提到 `pip install open3d`，安全扫描建议补齐声明；随 `scripts/` 一并发布）。
+
+### Changed
+
+- README / README_CN 开发章节：显式说明安装需 **pnpm 11.x**（仓库固定
+  `packageManager: pnpm@11.22.0`，CI 用 `pnpm/action-setup@v4` 安装匹配版本）与
+  Node `^22.19 || >=24`。
+
 ### Fixed
 
 - `ros2_workspace {action: "use", path}`：把 `source <path>` 前缀中的工作区

--- a/README.md
+++ b/README.md
@@ -485,6 +485,10 @@ bundles you need (or the `dsh-ros2` aggregate for the full set):
 ## Development
 
 ```bash
+Install with **pnpm 11.x** (the repo pins `packageManager: pnpm@11.22.0`; CI installs the matching
+pnpm via `pnpm/action-setup@v4`). Node `^22.19 || >=24` is required.
+
+```bash
 pnpm install
 pnpm run typecheck   # tsc --noEmit
 pnpm run test        # vitest (184 cases; plus 10 sidecar Python scenarios)

--- a/README_CN.md
+++ b/README_CN.md
@@ -467,6 +467,9 @@ dsh-ros2/                      # pnpm monorepo（工作区根，private）
 
 ## 开发
 
+安装需 **pnpm 11.x**（仓库固定 `packageManager: pnpm@11.22.0`；CI 通过 `pnpm/action-setup@v4` 安装匹配版本）。
+Node 需 `^22.19 || >=24`。
+
 ```bash
 pnpm install
 pnpm run typecheck   # tsc --noEmit

--- a/packages/vision/scripts/requirements.txt
+++ b/packages/vision/scripts/requirements.txt
@@ -1,0 +1,4 @@
+# Runtime dependency for the offscreen-mesh decimation helper
+# (simplify_visual_meshes.py). Install with:
+#   python3 -m pip install -r requirements.txt
+open3d>=0.18


### PR DESCRIPTION
## Summary

Daily-maintenance round (2026-09-05, no open issues → security-scan driven). Two low-risk hygiene fixes flagged by the security scan / prior-round recommendations:

1. **Declare the `open3d` runtime dependency** for the offscreen-mesh decimation helper `packages/vision/scripts/simplify_visual_meshes.py`.
   - Previously only the script docstring said `pip install open3d`; the dep was undeclared as a package artifact.
   - Adds `packages/vision/scripts/requirements.txt` (`open3d>=0.18`). The `scripts/` dir is already in the vision package `files` whitelist, so it ships with the published package.

2. **Document the toolchain requirement** in `README.md` / `README_CN.md`: Node `^22.19 || >=24` and **pnpm 11.x** (pinned via `packageManager: pnpm@11.22.0`, installed in CI by `pnpm/action-setup@v4`).

## Commits

- `chore(vision): declare open3d runtime dep for simplify_visual_meshes`
- `docs: state pnpm 11.x requirement in READMEs + CHANGELOG`

## Verification (local, all green)

- `CI=true pnpm run typecheck` → 10/10 projects tsc --noEmit Done
- `CI=true pnpm run test` → 184 vitest (1 pty skip) + sidecar `python3 -m sidecar.selftest` → `SELFTEST PASSED (10 scenarios)`
- `CI=true pnpm run build` → all packages Done

## Type of change

- [x] chore/dependency declaration
- [x] docs (no behavior change; no runtime-bundle reload needed)